### PR TITLE
add requirement for when-let

### DIFF
--- a/ammonite-term-repl.el
+++ b/ammonite-term-repl.el
@@ -41,6 +41,7 @@
 (require 'comint)
 (require 'scala-mode)
 (require 's)
+(require 'subr-x)
 
 (defgroup ammonite-term-repl nil
   "A minor mode for a Ammonite REPL."


### PR DESCRIPTION
I believe this should fix #5. Looks like `when-let` is part of a package that doesn't get included by default.